### PR TITLE
add goimports to setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ setup:
 	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 	go get -u github.com/pierrre/gotestcover
 	go get -u golang.org/x/tools/cmd/cover
+	go get -u golang.org/x/tools/cmd/goimports
 	mkdir build
 
 ## Run all the tests


### PR DESCRIPTION
Added `goimports` to Makefile to avoid the following:

Expected: Running `make fmt` after `make setup` will format my go files.
 
Actual:
```
root@88cdda7bc4fc:/go/go-project-setup# make fmt
Makefile:14: warning: overriding recipe for target 'docker-build'
Makefile:10: warning: ignoring old recipe for target 'docker-build'
find . -name '*.go' -not -wholename './vendor/*' | while read -r file; do gofmt -w -s "$file"; goimports -w "$file"; done
/bin/sh: 1: goimports: not found
/bin/sh: 1: goimports: not found
/bin/sh: 1: goimports: not found
/bin/sh: 1: goimports: not found
/bin/sh: 1: goimports: not found
/bin/sh: 1: goimports: not found
/bin/sh: 1: goimports: not found
/bin/sh: 1: goimports: not found
/bin/sh: 1: goimports: not found
/bin/sh: 1: goimports: not found
make: *** [Makefile:49: fmt] Error 127
root@88cdda7bc4fc:/go/go-project-setup# 
```